### PR TITLE
build: Correct path to static assets in build manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 include LICENSE
 include README.rst
 recursive-include pipelines/templates *
-recursive-include pipelinestatic *
+recursive-include pipelines/static *
 recursive-include docs *


### PR DESCRIPTION
Fixes #1